### PR TITLE
[FIX]: Apply Event 타입에 따라 TargetUserId 반환하는 메소드 구현

### DIFF
--- a/notification-application/src/main/kotlin/gloddy/notification/service/ApplyNotificationCreateService.kt
+++ b/notification-application/src/main/kotlin/gloddy/notification/service/ApplyNotificationCreateService.kt
@@ -1,6 +1,7 @@
 package gloddy.notification.service
 
 import gloddy.notification.*
+import gloddy.notification.NotificationType.APPLY_CREATE
 import gloddy.notification.dto.ApplyEvent
 import gloddy.notification.event.NotificationPushEvent
 import gloddy.notification.event.NotificationEventPublisher
@@ -19,7 +20,7 @@ class ApplyNotificationCreateService(
 
         Notification(
             redirectId = applyEvent.applyGroupId,
-            userId =  applyEvent.applyUserId,
+            userId =  getTargetUserId(type, applyEvent),
             content = type.content,
             type = type
         ).run { notificationCreatePort.save(this) }
@@ -34,5 +35,12 @@ class ApplyNotificationCreateService(
             redirectId = redirectId,
             type = type
         ).run { notificationEventPublisher.publishPushEvent(this) }
+    }
+
+    private fun getTargetUserId(type: NotificationType, applyEvent: ApplyEvent): UserId {
+        return when(type) {
+            in listOf(APPLY_CREATE) -> applyEvent.userId
+            else -> applyEvent.applyUserId
+        }
     }
 }

--- a/notification-domain/src/main/kotlin/gloddy/notification/NotificationType.kt
+++ b/notification-domain/src/main/kotlin/gloddy/notification/NotificationType.kt
@@ -9,14 +9,8 @@ enum class NotificationType(
     APPLY_CREATE("새로운 모임 지원서가 도착했어요!", true),
     GROUP_LEAVE("님이 그룹에서 나갔어요", true),
     GROUP_ARTICLE_CREATE("새로운 게시글을 확인해주세요", true),
-    GROUP_APPROACHING_START("""
-        1시간 뒤 모임이 시작돼요!
-        준비는 되었나요?
-    """.trimIndent(), true),
-    GROUP_END("""
-        모임은 즐거우셨나요?
-        함께 했던 인원들을 평가해주세요!
-    """.trimIndent(), false)
+    GROUP_APPROACHING_START("1시간 뒤 모임이 시작돼요! 준비는 되었나요?", true),
+    GROUP_END("모임은 즐거우셨나요? 함께 했던 인원들을 평가해주세요!", false)
     ;
 
     companion object {


### PR DESCRIPTION
## Issue
* resolved #11 

## 작업 사항
* apply event 타입에 상관없이 모두 지원서를 작성한 유저에게 알림이 전송되도록 구현되어 있어 수정했습니다.
* 지원서 생성 시 그룹의 캡틴에게 알림, 지원서 승인/거절 시에는 지원서를 작성한 유저에게 알림이 전송되어야 합니다.
* 따라서, Apply Event 타입에 따라 알림을 보낼 targetUserId를 반환하는 메소드를 구현했습니다.