### PR TITLE
[FIX]: GroupMember Payload, Event 및 FeignClient 수정

### DIFF
--- a/in-adapter-messaging/src/main/kotlin/gloddy/handler/mapper/ApplicationEventMapper.kt
+++ b/in-adapter-messaging/src/main/kotlin/gloddy/handler/mapper/ApplicationEventMapper.kt
@@ -1,5 +1,6 @@
 package gloddy.handler.mapper
 
+import gloddy.notification.UserId
 import gloddy.notification.dto.event.eventType.ApplyEventType
 import gloddy.notification.dto.event.eventType.GroupMemberEventType
 import gloddy.notification.dto.event.ApplyEvent
@@ -21,7 +22,8 @@ fun GroupArticlePayload.toDomainEvent(): GroupArticleEvent =
 
 fun GroupMemberPayload.toDomainEvent(): GroupMemberEvent =
     GroupMemberEvent(
-        groupMemberId = this.groupMemberId,
+        userId = UserId(this.userId),
+        groupId = this.groupId,
         eventType = this.eventType.toDomainEventType(),
         eventDateTime = this.eventDateTime
     )

--- a/in-adapter-messaging/src/main/kotlin/gloddy/payload/group/GroupMemberPayload.kt
+++ b/in-adapter-messaging/src/main/kotlin/gloddy/payload/group/GroupMemberPayload.kt
@@ -3,7 +3,8 @@ package gloddy.payload.group
 import java.time.LocalDateTime
 
 data class GroupMemberPayload(
-    val groupMemberId: Long,
+    val userId: Long,
+    val groupId: Long,
     val eventType: GroupMemberPayloadType,
     val eventDateTime: LocalDateTime
 )

--- a/notification-application/src/main/kotlin/gloddy/notification/dto/event/GroupMemberEvent.kt
+++ b/notification-application/src/main/kotlin/gloddy/notification/dto/event/GroupMemberEvent.kt
@@ -1,10 +1,12 @@
 package gloddy.notification.dto.event
 
+import gloddy.notification.UserId
 import gloddy.notification.dto.event.eventType.GroupMemberEventType
 import java.time.LocalDateTime
 
 data class GroupMemberEvent(
-    val groupMemberId: Long,
+    val userId: UserId,
+    val groupId: Long,
     val eventType: GroupMemberEventType,
     val eventDateTime: LocalDateTime
 )

--- a/notification-application/src/main/kotlin/gloddy/notification/port/out/GroupPayloadGetPort.kt
+++ b/notification-application/src/main/kotlin/gloddy/notification/port/out/GroupPayloadGetPort.kt
@@ -1,5 +1,6 @@
 package gloddy.notification.port.out
 
+import gloddy.notification.UserId
 import gloddy.notification.dto.event.eventType.GroupArticleEventType
 import gloddy.notification.dto.event.eventType.GroupEventType
 import gloddy.notification.dto.event.eventType.GroupMemberEventType
@@ -10,5 +11,5 @@ import gloddy.notification.dto.payload.GroupPayload
 interface GroupPayloadGetPort {
     fun getGroupPayload(groupId: Long, eventType: GroupEventType): GroupPayload
     fun getGroupArticlePayload(articleId: Long, eventType: GroupArticleEventType): GroupArticlePayload
-    fun getGroupMemberPayload(groupMemberId: Long, eventType: GroupMemberEventType): GroupMemberPayload
+    fun getGroupMemberPayload(userId: Long, groupId: Long, eventType: GroupMemberEventType): GroupMemberPayload
 }

--- a/notification-application/src/main/kotlin/gloddy/notification/service/GroupNotificationCreateService.kt
+++ b/notification-application/src/main/kotlin/gloddy/notification/service/GroupNotificationCreateService.kt
@@ -38,7 +38,7 @@ class GroupNotificationCreateService(
     }
 
     override fun create(event: GroupMemberEvent) {
-        val payload = groupPayloadGetPort.getGroupMemberPayload(event.groupMemberId, event.eventType)
+        val payload = groupPayloadGetPort.getGroupMemberPayload(event.userId.value,event.groupId, event.eventType)
         val notificationType = NotificationType.of(event.eventType.name)
 
         Notification(

--- a/out-internal-api/src/main/kotlin/gloddy/openFeign/client/GroupPayloadGetClient.kt
+++ b/out-internal-api/src/main/kotlin/gloddy/openFeign/client/GroupPayloadGetClient.kt
@@ -27,9 +27,10 @@ interface GroupPayloadGetClient : GroupPayloadGetPort {
         @RequestParam("eventType") eventType: GroupArticleEventType
     ): GroupArticlePayload
 
-    @GetMapping("/groups/members/{groupMemberId}")
+    @GetMapping("/groups/{groupId}/members/{userId}")
     override fun getGroupMemberPayload(
-        @PathVariable("groupMemberId") groupMemberId: Long,
+        @PathVariable("userId") userId: Long,
+        @PathVariable("groupId") groupId: Long,
         @RequestParam("eventType") eventType: GroupMemberEventType
     ): GroupMemberPayload
 }


### PR DESCRIPTION
resolved #26 
resolved #27 
## 문제 상황
현재 GroupMember에 대한 이벤트는 groupMemberId(그룹 멤버 자체의 식별자)만 전달을 하고 있습니다.
근데 기존 서버에서는 GroupMember가 Group을 떠날 시 soft-delete가 아닌 그냥 삭제를 해버리기 때문에 groupMemberId를 통해서 FeignClient로 기존서버에 정보를 들고 올 때 문제가 발생합니다.

## 그에 따른 작업 고려 사항
1. 기존 서버에 GroupMember 삭제를 soft-delete로 바꾼다.(고려한 해결방법)
위의 방법으로 문제를 해결하는 것을 고려하였지만, 기존 서버의 수많은 로직들이 GroupMember와 엮여져 있어 변경사항이 전파되는 문제 때문에 위 방법으로는 해결하지 않았습니다.
2. GroupMember 이벤트 Payload를 변경한다. (선택한 해결방법)
GroupMember Payload를 groupMemberId가 아닌 userId, groupId로 변경하였습니다. groupMemberId 보다 user 및 group의 정보를 들고오기에 더 유연하다고 판단하였고, 이 변경으로 변경 전파가 크지 않다고 판단하였습니다.

- 기존 GroupMemberEventPayload
```kotlin
data class GroupMemberPayload(
    val groupMemberId: Long,
    val eventType: GroupMemberPayloadType,
    val eventDateTime: LocalDateTime
)
```
- 변경된 GroupMemberEventPayload
```kotlin
data class GroupMemberPayload(
    val userId: Long,
    val groupId: Long,
    val eventType: GroupMemberPayloadType,
    val eventDateTime: LocalDateTime
)
```