### PR TITLE
[Fix]: DynamoDB 테이블 명 stage에 따라 동적으로 할당할 수 있게 변경

### DIFF
--- a/notification-out-adapter-persistence/src/main/kotlin/gloddy/dynamodb/config/DynamoDBConfig.kt
+++ b/notification-out-adapter-persistence/src/main/kotlin/gloddy/dynamodb/config/DynamoDBConfig.kt
@@ -5,8 +5,10 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.dynamodbv2.datamodeling.ConversionSchemas
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverterFactory
 import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -14,18 +16,36 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 
 @Configuration
-@EnableDynamoDBRepositories(basePackages = ["gloddy.dynamodb.notification", "gloddy.dynamodb.fcmToken"])
+@EnableDynamoDBRepositories(basePackages = ["gloddy.dynamodb.notification", "gloddy.dynamodb.fcmToken"], dynamoDBMapperConfigRef = "dynamoDBMapperConfig")
 class DynamoDBConfig(
     @Value("\${amazon.dynamodb.endpoint}") private val endpoint: String,
     @Value("\${amazon.aws.accessKey}") private val accessKey: String,
     @Value("\${amazon.aws.secretKey}") private val secretKey: String,
-    @Value("\${amazon.aws.region}") private val region: String
+    @Value("\${amazon.aws.region}") private val region: String,
+    @Value("\${stage}") private val stage: String
 ) {
 
     @Primary
     @Bean
     fun dynamoDBMapper(amazonDynamoDB: AmazonDynamoDB): DynamoDBMapper {
-        return DynamoDBMapper(amazonDynamoDB, DynamoDBMapperConfig.DEFAULT)
+        return DynamoDBMapper(
+            amazonDynamoDB,
+            dynamoDBMapperConfig()
+        )
+    }
+
+    @Bean
+    fun dynamoDBMapperConfig(): DynamoDBMapperConfig {
+        return DynamoDBMapperConfig.builder()
+            .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.UPDATE)
+            .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.EVENTUAL)
+            .withPaginationLoadingStrategy(DynamoDBMapperConfig.PaginationLoadingStrategy.LAZY_LOADING)
+            .withTableNameResolver(tableNameResolver())
+            .withBatchWriteRetryStrategy(DynamoDBMapperConfig.DefaultBatchWriteRetryStrategy.INSTANCE)
+            .withBatchLoadRetryStrategy(DynamoDBMapperConfig.DefaultBatchLoadRetryStrategy.INSTANCE)
+            .withTypeConverterFactory(DynamoDBTypeConverterFactory.standard())
+            .withConversionSchema(ConversionSchemas.V2_COMPATIBLE)
+            .build()
     }
 
     @Bean
@@ -41,4 +61,8 @@ class DynamoDBConfig(
 
     @Bean
     fun awsCredentials() = BasicAWSCredentials(accessKey, secretKey)
+
+    @Bean
+    @Primary
+    fun tableNameResolver() = TableNameResolver(stage)
 }

--- a/notification-out-adapter-persistence/src/main/kotlin/gloddy/dynamodb/config/TableNameResolver.kt
+++ b/notification-out-adapter-persistence/src/main/kotlin/gloddy/dynamodb/config/TableNameResolver.kt
@@ -1,0 +1,34 @@
+package gloddy.dynamodb.config
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
+
+class TableNameResolver(
+    private val stage: String
+) : DynamoDBMapperConfig.TableNameResolver {
+
+    companion object {
+        const val STG: String = "stg"
+        const val PRD: String = "prd"
+    }
+
+    override fun getTableName(clazz: Class<*>?, config: DynamoDBMapperConfig?): String {
+
+        val tableNameOverride = config?.tableNameOverride
+        if (tableNameOverride != null) {
+            val tableName = tableNameOverride.tableName
+            if (tableName != null)
+                return tableName
+        }
+
+        val rawTableName = clazz?.getAnnotation(DynamoDBTable::class.java)?.tableName
+            ?: throw DynamoDBMappingException("$clazz not annotated with @DynamoDBTable")
+
+        return when (stage) {
+            STG -> rawTableName
+            PRD -> "${rawTableName}_$stage"
+            else -> throw RuntimeException("Invalid stage: $stage")
+        }
+    }
+}

--- a/notification-out-adapter-persistence/src/main/resources/application-dynamodb.yml
+++ b/notification-out-adapter-persistence/src/main/resources/application-dynamodb.yml
@@ -1,3 +1,5 @@
+stage: ${DYNAMODB_STAGE}
+
 amazon:
   dynamodb:
     endpoint: ${DYNAMODB_END_POINT}


### PR DESCRIPTION
## 문제상황
- Dynamodb는 RDB와 같이 database 개념이 없기 때문에 오로지 테이블 명 만으로 테이블을 생성할 수 있는데, 그러면 테이블이 개발/운영에 따라 이름이 달라져야함.

## 해결 및 작업한 일
- [X] Dynamodb Custom TableNameResolver 구현
- [X] DynamodbMapperConfig Custom TableNameResolver 사용하도록 설정 변경