### PR TITLE
[Infra]: SQS Long polling(20초)에 따른 Spring SQS Listener poll-timeout 변경

### DIFF
--- a/in-adapter-messaging/src/main/resources/application-message.yml
+++ b/in-adapter-messaging/src/main/resources/application-message.yml
@@ -8,7 +8,7 @@ spring:
         secret-key: ${AWS_SECRET_KEY}
       sqs:
         listener:
-          poll-timeout: 20
+          poll-timeout: 30000
 
 sqs:
   queue:


### PR DESCRIPTION
## 작업한 일 😞
- SQS Long polling(20초)에 따른 Spring SQS Listener poll-timeout 변경
   - timeout : 30초

## 작업한 이유 🧐
- SQS short polling으로 인해 SQS 가격이 너무 많이 나와 Long polling으로 AWS 비용을 낮추기 위함.